### PR TITLE
Multi-Flavor maven publication support

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.library'
+    id 'maven-publish'
 }
 
 android {
@@ -47,6 +48,22 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.annotation:annotation:1.3.0'
+}
 
-implementation 'androidx.annotation:annotation:1.3.0'
+afterEvaluate {
+    android.libraryVariants.each { variant ->
+        // Only consider release
+        if (variant.buildType.name != "release") { return }
+        def libraryGroupId = 'com.cluby'
+        def libraryArtifactId = 'pwa-wrapper'
+        def libraryVersion = '1.0'
+
+        publishing.publications.create(variant.name, MavenPublication) {
+            from components.findByName(variant.name)
+            groupId libraryGroupId
+            artifactId "${libraryArtifactId}-${variant.flavorName}"
+            version libraryVersion
+        }
+    }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -57,7 +57,7 @@ afterEvaluate {
         if (variant.buildType.name != "release") { return }
         def libraryGroupId = 'com.cluby'
         def libraryArtifactId = 'pwa-wrapper'
-        def libraryVersion = '1.0'
+        def libraryVersion = '1.5'
 
         publishing.publications.create(variant.name, MavenPublication) {
             from components.findByName(variant.name)


### PR DESCRIPTION
Note that the jitpack.io rename the groupId to github account automatically. the final log for jitpack will be as follow:
![image](https://user-images.githubusercontent.com/24825921/153362371-3d4b978e-452f-432e-895a-93ab9b1ed996.png)
https://jitpack.io/com/github/vahid-m/cluby-pwa-wrapper/1.5/build.log